### PR TITLE
Update restore

### DIFF
--- a/scripts/restore
+++ b/scripts/restore
@@ -71,7 +71,7 @@ chown -R $app:www-data "$final_path"
 #=================================================
 # RESTORE THE DATA DIRECTORY
 #=================================================
-ynh_script_progression --message="Restoring the data directory..." --time --weight=1
+ynh_script_progression --message="Restoring the data directory..." --weight=1
 
 ynh_restore_file --origin_path="$datadir" --not_mandatory
 


### PR DESCRIPTION
Fix Using 'ynh_script_progression --time' should only be for calibrating the weight (c.f. '--weight'). It's not meant to be kept for production versions.