### PR TITLE
Kiwix upload config panel

### DIFF
--- a/config_panel.toml
+++ b/config_panel.toml
@@ -10,7 +10,7 @@ name.en = "Upload content"
         type = "string"
         ask.en = "Content URL"
         help.en = "For example: https://download.kiwix.org/zim/other/pokepedia_fr_all_maxi_2021-01.zim"
-        help.fr = "Par exemple: https://download.kiwix.org/zim/other/pokepedia_fr_all_maxi_2021-01.zim"
+        help.fr = "Par exemple : https://download.kiwix.org/zim/other/pokepedia_fr_all_maxi_2021-01.zim"
 
         [main.upload.upload_button]
         ask.en = "Upload"

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -1,0 +1,18 @@
+version = "1.0"
+
+[main]
+name.en = "Upload content"
+
+    [main.upload]
+
+        [main.upload.upload_url]
+        default = ""
+        type = "string"
+        ask.en = "Content URL"
+        help.en = "For example: https://download.kiwix.org/zim/other/pokepedia_fr_all_maxi_2021-01.zim"
+
+        [main.upload.upload_button]
+        ask.en = "Upload"
+        type = "button"
+        style = "success"
+        enabled = "upload_url"

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -10,6 +10,7 @@ name.en = "Upload content"
         type = "string"
         ask.en = "Content URL"
         help.en = "For example: https://download.kiwix.org/zim/other/pokepedia_fr_all_maxi_2021-01.zim"
+        help.fr = "Par exemple: https://download.kiwix.org/zim/other/pokepedia_fr_all_maxi_2021-01.zim"
 
         [main.upload.upload_button]
         ask.en = "Upload"

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -1,5 +1,9 @@
 ### How to add zim files?
 
+#### Add a zin file through its URL
+- Click on the "Upload content" tab above.
+
+#### Add a zim file by hand
 - Download one or more ZIM files, e.g. from [https://download.kiwix.org/zim/](https://download.kiwix.org/zim/)
 - Put the ZIM files into `__DATA_DIR__`
 - Add them to the library with the following command:

--- a/doc/ADMIN_fr.md
+++ b/doc/ADMIN_fr.md
@@ -1,5 +1,10 @@
 ### Comment ajouter des fichiers ZIM ?
 
+
+#### Ajouter un fichier ZIM via son URL
+- Sélectionnez l'onglet "Upload content" qui se trouve ci-dessus.
+
+#### Ajouter un fichier ZIM à la main
 - Téléchargez un ou plusieurs fichiers ZIM, par ex. [https://download.kiwix.org/zim/](https://download.kiwix.org/zim/)
 - Mettez les fichiers ZIM dans `__DATA_DIR__/`
 - Ajoutez-les à la bibliothèque avec la commande suivante :

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Kiwix"
 description.en = "Sharing Web content with people without Internet access"
 description.fr = "Partager du contenu Web avec des personnes sans accès à Internet"
 
-version = "3.5.0~ynh3"
+version = "3.5.0~ynh4"
 
 maintainers = ["eric_G"]
 

--- a/scripts/config
+++ b/scripts/config
@@ -6,7 +6,7 @@ function run__upload_button() {
     local data_dir=$(ynh_app_setting_get --app=$app --key=data_dir)
     local filename="$(echo "$upload_url"  | awk -F/ '{print $NF}')"
     ynh_print_info --message="Downloading file…"
-    wget --tries 3 --no-dns-cache --timeout 900 --output-document="$data_dir/$filename" "$upload_url" 2>>
+    wget --tries 3 --no-dns-cache --timeout 900 --output-document="$data_dir/$filename" "$upload_url" 2>&1
     ynh_print_info --message="Adding file to Kiwix library"
     $install_dir/kiwix-manage $data_dir/library.xml add "$data_dir/$filename"
     yunohost service restart kiwix

--- a/scripts/config
+++ b/scripts/config
@@ -1,0 +1,15 @@
+#!/bin/bash
+source /usr/share/yunohost/helpers
+ynh_abort_if_errors
+
+function run__upload_button() {
+    local data_dir=$(ynh_app_setting_get --app=$app --key=data_dir)
+    local filename="$(echo "$upload_url"  | awk -F/ '{print $NF}')"
+    ynh_print_info --message="Downloading file…"
+    wget --tries 3 --no-dns-cache --timeout 900 --output-document="$data_dir/$filename" "$upload_url" 2>>
+    ynh_print_info --message="Adding file to Kiwix library"
+    $install_dir/kiwix-manage $data_dir/library.xml add "$data_dir/$filename"
+    yunohost service restart kiwix
+}
+
+ynh_app_config_run $1


### PR DESCRIPTION
On a trouvé que c'était pas commode d'installer des fichiers ZIM à la main dans Kiwix pour des personnes qui flippent à l'idée d'ouvrir un terminal. Du coup, on a bricolé un petit outil pour uploader un fichier ZIM via une URL.
Bisous !